### PR TITLE
Fix preloader counter when using Swup

### DIFF
--- a/resources/js/web/plugins/swup.js
+++ b/resources/js/web/plugins/swup.js
@@ -10,16 +10,16 @@ const swup = new Swup();
 
 // 1. 点击链接后、切换开始前
 swup.hooks.on("visit:start", () => {
-  // 清零并启动数字加载器
+  // 清零数字计数并启动加载器动画
   document.querySelector(".loader__count .count__text").textContent = "0";
+  startLoader();
   // 播放出场动画
   transitOut();
 });
 
 // 2. Swup 将新内容替换到 DOM 之后
 swup.hooks.on("content:replace", () => {
-  // 播放入场动画
-  startLoader();
+  // 页面内容替换后无特殊操作，保留钩子以便后续扩展
 });
 
 // 3. 切换完成（浏览器历史、滚动位置都已就绪）


### PR DESCRIPTION
## Summary
- trigger `startLoader()` at the beginning of Swup transitions so the counter becomes visible
- keep `content:replace` hook for future use

## Testing
- `npm test` *(fails: Missing script: "test")*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693be517148325aaa21c0fa091721f