### PR TITLE
Fix rgbKineticSlider images load

### DIFF
--- a/public/js/lib/rgbKineticSlider.js
+++ b/public/js/lib/rgbKineticSlider.js
@@ -92,6 +92,14 @@
         let slideTexts;
         let slideTextsSub;
 
+        // preload images so that imagesLoaded can track them
+        const images = [];
+        for (let i = 0; i < options.slideImages.length; i++) {
+            const img = new Image();
+            img.src = options.slideImages[i];
+            images.push(img);
+        }
+
         // slide index
         let currentIndex = 0;
         // swipping flag


### PR DESCRIPTION
## Summary
- fix undefined `images` variable in `rgbKineticSlider`

## Testing
- `composer test` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871f442d43883258f1a31096115e378