### PR TITLE
Fix rgbKineticSlider Pixi.js call

### DIFF
--- a/public/js/lib/rgbKineticSlider.js
+++ b/public/js/lib/rgbKineticSlider.js
@@ -73,7 +73,7 @@
         const textsSubContainer = new PIXI.Container();
 
         // displacement variables used for slides transition 
-        const dispSprite = new PIXI.Sprite.from(options.backgroundDisplacementSprite );
+        const dispSprite = PIXI.Sprite.from(options.backgroundDisplacementSprite );
         const dispFilter = new PIXI.filters.DisplacementFilter(dispSprite);
 
         // displacement variables used for cursor moving effect


### PR DESCRIPTION
## Summary
- fix incorrect instantiation of Pixi Sprite in rgbKineticSlider

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871f7ba4d3c83258ee98b266914c705