### PR TITLE
Add responsive GSAP fade amount

### DIFF
--- a/resources/js/web/shared/gsapFade.js
+++ b/resources/js/web/shared/gsapFade.js
@@ -1,0 +1,59 @@
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import $ from "jquery";
+import { isMobile } from "../utils";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export function initGsapFade() {
+    const $elements = $("[data-gsap-fade]");
+    $elements.each(function () {
+        const $el = $(this);
+        const type = $el.data("gsap-fade");
+        const fromVars = { autoAlpha: 0 };
+
+        const defaultAmount = 50;
+        let amount = defaultAmount;
+
+        if ($el.is("[data-fade-amount]")) {
+            amount = parseFloat($el.data("fade-amount"));
+        }
+
+        if (isMobile()) {
+            if ($el.is("[data-fade-amount-mobile]")) {
+                amount = parseFloat($el.data("fade-amount-mobile"));
+            }
+        } else if ($el.is("[data-fade-amount-desktop]")) {
+            amount = parseFloat($el.data("fade-amount-desktop"));
+        }
+
+        switch (type) {
+            case "left":
+                fromVars.x = -amount;
+                break;
+            case "right":
+                fromVars.x = amount;
+                break;
+            case "top":
+                fromVars.y = -amount;
+                break;
+            case "bottom":
+                fromVars.y = amount;
+                break;
+            case "only":
+            default:
+                break; // only fade
+        }
+
+        gsap.from($el[0], {
+            ...fromVars,
+            ease: "power2.out",
+            duration: 1,
+            scrollTrigger: {
+                trigger: $el[0],
+                start: "top 80%",
+                toggleActions: "play none none reverse",
+            },
+        });
+    });
+}

--- a/resources/js/web/template/theme.js
+++ b/resources/js/web/template/theme.js
@@ -10,6 +10,7 @@ import lgZoom from "lightgallery/plugins/zoom";
 import Swiper from "swiper/bundle";
 import { ScrollToPlugin } from "gsap/ScrollToPlugin";
 import { isMobile } from "./../utils";
+import { initGsapFade } from "../shared/gsapFade";
 
 gsap.registerPlugin(ScrollTrigger, ScrollToPlugin);
 
@@ -3735,6 +3736,9 @@ export default function initTemplate() {
     $(".tt-btn-disabled").on("click", function () {
         return false;
     });
+
+    // Initialize GSAP fade animations
+    initGsapFade();
 
     // Force page scroll position to top on refresh (do not remove!)
     // =============================================


### PR DESCRIPTION
## Summary
- extend `initGsapFade` to read jQuery data attributes
- add `data-fade-amount(-mobile|-desktop)` options
- apply amount to GSAP animations so offsets differ per device

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_687515d2125483258d1bba0efc5c5dbd