### PR TITLE
Fix preloader wrapper

### DIFF
--- a/resources/js/web/plugins/swup.js
+++ b/resources/js/web/plugins/swup.js
@@ -19,16 +19,15 @@ const swup = new Swup({
 
 // 1. 点击链接后、切换开始前
 swup.hooks.on("visit:start", () => {
-    // 清零并启动数字加载器
+    // 清零计数并启动加载动画
     document.querySelector(".loader__count .count__text").textContent = "0";
-    // 播放出场动画
+    startLoader();
     transitOut();
 });
 
 // 2. Swup 将新内容替换到 DOM 之后
 swup.hooks.on("content:replace", () => {
     // 播放入场动画
-    startLoader();
     transitIn();
 });
 

--- a/resources/js/web/template/loader.js
+++ b/resources/js/web/template/loader.js
@@ -9,6 +9,7 @@ import initTemplate from "./theme";
 gsap.registerPlugin(ScrollTrigger);
 
 export function transitOut() {
+    document.getElementById("loader").classList.remove("loaded");
     const tl = gsap.timeline({
         defaults: { duration: 1.2, ease: Expo.easeInOut },
     });

--- a/resources/js/web/template/loader.js
+++ b/resources/js/web/template/loader.js
@@ -9,14 +9,29 @@ import initTemplate from "./theme";
 gsap.registerPlugin(ScrollTrigger);
 
 export function transitOut() {
-    document.getElementById("loader").classList.remove("loaded");
     const tl = gsap.timeline({
         defaults: { duration: 1.2, ease: Expo.easeInOut },
     });
 
-    // header and footer 隐藏
+    document.getElementById("loader").classList.remove("loaded");
+
+    // reset loader__count
+    tl.to(".loader__count", {
+        y: "-100%",
+        ease: Expo.easeInOut,
+        onComplete: () => {
+            document.querySelector(".loader__count .count__text").textContent = "0";
+        },
+    });
+
+    // loader__wrapper
+    tl.to(".loader__wrapper", {
+        y: "0%",
+        ease: Expo.easeInOut,
+    });
+
+    // Hide header and footer
     tl.to("#tt-header", {
-        duration: 1.5,
         y: -20,
         autoAlpha: 0,
         ease: Expo.easeInOut,
@@ -25,54 +40,11 @@ export function transitOut() {
     tl.to(
         "#tt-footer",
         {
-            duration: 1.5,
             y: -20,
             autoAlpha: 0,
             ease: Expo.easeInOut,
         },
-        "<0.2"
-    );
-
-    tl.to("#content-wrap", {
-        y: 80,
-        autoAlpha: 0,
-        duration: 1.2,
-        ease: Expo.easeInOut,
-    });
-
-    // 0. 确保整个 loader 可见并重置位置
-    tl.set("#loader", { autoAlpha: 1 });
-    tl.set([".loader__wrapper", ".loader__count"], { y: 0 });
-
-    // 1. loader wrapper 从上方滑入
-    tl.fromTo(
-        ".loader__wrapper",
-        { y: "-100%", autoAlpha: 0 },
-        { y: "0%", autoAlpha: 1, duration: 0.6, ease: Expo.easeOut }
-    );
-
-    // 2. 数字容器弹入
-    tl.fromTo(
-        ".loader__count",
-        { scale: 0.8, autoAlpha: 0 },
-        { scale: 1, autoAlpha: 1, duration: 0.6, ease: "back.out(1.7)" },
-        "<0.3"
-    );
-
-    // 3. 蒙层展开
-    tl.fromTo(
-        ".ptr-overlay",
-        { scaleY: 0, transformOrigin: "top center" },
-        { scaleY: 1 },
         "<"
-    );
-
-    // 4. 预加载器主体显示
-    tl.fromTo(
-        ".ptr-preloader",
-        { autoAlpha: 0, scale: 0.8 },
-        { autoAlpha: 1, scale: 1 },
-        "<0.2"
     );
 }
 
@@ -80,13 +52,6 @@ export function transitIn() {
     const tl = gsap.timeline({
         defaults: { duration: 1.2, ease: Expo.easeInOut },
     });
-
-    // Hide preloader and overlay
-    // tl.to(".ptr-preloader", { autoAlpha: 0 }, 0);
-
-    tl.to(".ptr-overlay", { scaleY: 0, transformOrigin: "top center" }, ">2");
-
-    tl.from("#content-wrap", { y: -80, autoAlpha: 0 });
 
     // Animate header and footer in
     tl.from("#tt-header", {

--- a/resources/js/web/template/loader.js
+++ b/resources/js/web/template/loader.js
@@ -40,14 +40,13 @@ export function transitOut() {
     });
 
     // 0. 确保整个 loader 可见
-    tl.set("#loader", { autoAlpha: 1 }, 0);
+    tl.set("#loader", { autoAlpha: 1 });
 
     // 1. loader wrapper 从上方滑入
     tl.fromTo(
         ".loader__wrapper",
         { y: "-100%", autoAlpha: 0 },
-        { y: "0%", autoAlpha: 1, duration: 0.6, ease: Expo.easeOut },
-        0
+        { y: "0%", autoAlpha: 1, duration: 0.6, ease: Expo.easeOut }
     );
 
     // 2. 数字容器弹入
@@ -55,7 +54,7 @@ export function transitOut() {
         ".loader__count",
         { scale: 0.8, autoAlpha: 0 },
         { scale: 1, autoAlpha: 1, duration: 0.6, ease: "back.out(1.7)" },
-        0.3
+        "<0.3"
     );
 
     // 3. 蒙层展开
@@ -63,7 +62,7 @@ export function transitOut() {
         ".ptr-overlay",
         { scaleY: 0, transformOrigin: "top center" },
         { scaleY: 1 },
-        0
+        "<"
     );
 
     // 4. 预加载器主体显示
@@ -71,7 +70,7 @@ export function transitOut() {
         ".ptr-preloader",
         { autoAlpha: 0, scale: 0.8 },
         { autoAlpha: 1, scale: 1 },
-        0.2
+        "<0.2"
     );
 }
 

--- a/resources/js/web/template/loader.js
+++ b/resources/js/web/template/loader.js
@@ -40,8 +40,9 @@ export function transitOut() {
         ease: Expo.easeInOut,
     });
 
-    // 0. 确保整个 loader 可见
+    // 0. 确保整个 loader 可见并重置位置
     tl.set("#loader", { autoAlpha: 1 });
+    tl.set([".loader__wrapper", ".loader__count"], { y: 0 });
 
     // 1. loader wrapper 从上方滑入
     tl.fromTo(

--- a/resources/scss/web/template/loader.scss
+++ b/resources/scss/web/template/loader.scss
@@ -233,7 +233,7 @@
     display: -ms-inline-flexbox;
     display: inline-flex;
     font: normal var(--font-weight-base) 4.6rem/0.9 var(--_font-accent);
-    color: #2e2e2e;
+    color: var(--neutral-white);
 }
 @media only screen and (min-width: 768px) {
     .loader__count span {

--- a/resources/scss/web/template/theme.scss
+++ b/resources/scss/web/template/theme.scss
@@ -227,6 +227,7 @@ body.tt-transition .ptr-overlay {
     height: 100vh;
     background-color: #111;
     z-index: 1;
+    pointer-events: none;
 }
 
 /* Transition preloader */

--- a/resources/views/web/layout/preloader.blade.php
+++ b/resources/views/web/layout/preloader.blade.php
@@ -8,5 +8,3 @@
         </div>
     </div>
 </div>
-
-<div class="ptr-overlay"></div>

--- a/resources/views/web/layout/preloader.blade.php
+++ b/resources/views/web/layout/preloader.blade.php
@@ -1,8 +1,10 @@
-<div id="loader" class="ptr-preloader">
-    <div class="loader__content">
-        <div class="loader__count">
-            <span class="count__text">0</span>
-            <span class="count__percent">%</span>
+<div id="loader" class="loader ptr-preloader">
+    <div class="loader__wrapper">
+        <div class="loader__content">
+            <div class="loader__count">
+                <span class="count__text">0</span>
+                <span class="count__percent">%</span>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add missing `.loader__wrapper` in preloader markup
- adjust GSAP timeline so header hides before loader appears

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68751ecb00dc8325a7bda73c3cec475d