### PR TITLE
Fix kinetic slider init when element missing

### DIFF
--- a/resources/js/web/plugins/rgbKineticSlider.js
+++ b/resources/js/web/plugins/rgbKineticSlider.js
@@ -1,4 +1,10 @@
 export function initKineticSlider() {
+    const sliderEl = document.getElementById("kinetic-slider");
+    if (!sliderEl) {
+        // Slider element not present on the current page
+        return;
+    }
+
     const images = ["images/home/banner.jpg", "images/home/banner.jpg"];
 
     window.rgbKineticSlider = new rgbKineticSlider({


### PR DESCRIPTION
## Summary
- avoid initializing kinetic slider when the element is absent

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden)*
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687523df30cc832581646399bbc3a7d2